### PR TITLE
bump backoff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "pipelinewise-singer-python==1.*",
         "google-api-python-client==1.7.9",
         "oauth2client==4.1.3",
-        "backoff==1.3.2"
+        "backoff==1.8.0"
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
This PR bumps backoff to `1.8.0`. The currently used `backoff-1.3.2` casusing dependency issues with the downstream [pipelinewise-singer-pythong](https://github.com/transferwise/pipelinewise-singer-python/blob/8c828c8d91220e05900beddd8dc46027af216e00/setup.py#L24)

