### PR TITLE
Add support for the 'ga:segment' dimension with segment IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,34 @@ For example, if you want to extract user stats per day in a users_per_day stream
 You can check [tap-google-analytics/defaults/default_report_definition.json](tap-google-analytics/defaults/default_report_definition.json) for a more lengthy, detailed example.
 
 
+##### Segments
+
+If you want to use the `ga:segment` dimension, you must specify the segment IDs in your reports.json stream / report config:
+
+```
+[
+  {
+    "name": "acquisition",
+    "dimensions": [
+      "ga:date",
+      "ga:segment",
+      "ga:channelGrouping"
+    ],
+    "metrics": [
+      "ga:users",
+      "ga:newUsers",
+      "ga:sessions"
+    ],
+    "segments": [
+      "gaid::-1",
+      "gaid::U7LSsrWRTq6JIIS8G8brrQ"
+    ]
+  }
+]
+```
+
+Segment IDs can be found with the [GA Query explorer](https://ga-dev-tools.appspot.com/query-explorer). The account configured for authentication must either own the segment, or have "Collaborate" access to the GA view as well as the segment itself having its Segment Availability set to "Collaborators and I can apply/edit Segment in this View".
+
 ## Run
 
 ```bash


### PR DESCRIPTION
## Problem

* GA allows reports to be filtered by a list of standard and user editable segments (e.g only Chrome Users, only sessions with Transactions etc).
* These segments are viewable and editable via GA's web interface.
* Use of `ga:segment` as a dimension via the Reporting API requires either segment IDs or segment definitions
* https://developers.google.com/analytics/devguides/reporting/core/v3/segments

## Proposed changes

* This PR adds support for a new top level report config `segments` when 'ga:segment` has been added to `dimensions`
* `segments` contains a list of segment IDs
* Segment IDs are stored in the catalog/properties.json in a metadata field for the 'ga_segment' dimension property
* Segment IDs are added to the GA query if they exist
* README has been updated with an example

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
